### PR TITLE
successful signing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,16 +21,18 @@ export default function Home() {
       publicKey: result.publicKey,
       signature: result.signature as Uint8Array,
       accountId: result.accountId
-    }
+    };
     const option1 = verifySignerSignature(btoa(messageToSign), signatureMap, result.publicKey);
     console.log(option1);
 
+    const signedMessage = prefixMessageToSign(btoa(messageToSign));
+    console.log(signedMessage);
     const verified = result.publicKey.verify(
-      Buffer.from(prefixMessageToSign(btoa(messageToSign))),
+      Buffer.from(signedMessage),
       result.signature
     );
 
-    alert(`The signature was ${verified ? "verified" : "not verified"}`);
+    alert(`The signature was ${verified ? "verified" : "not verified"} for signedMessage: "${signedMessage}"`);
   }
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import {
   useWallet,
 } from "@buidlerlabs/hashgraph-react-wallets";
 import { HashpackConnector } from "@buidlerlabs/hashgraph-react-wallets/connectors";
+import {verifySignerSignature, prefixMessageToSign } from '@hashgraph/hedera-wallet-connect'
+import type { SignerSignature } from "@hashgraph/sdk";
 
 const messageToSign = "Hello, world!";
 
@@ -14,10 +16,20 @@ export default function Home() {
   async function signAndVerify() {
     await connect();
     const result = await signAuth(messageToSign);
+    console.log(result)
+    const signatureMap:SignerSignature = {
+      publicKey: result.publicKey,
+      signature: result.signature as Uint8Array,
+      accountId: result.accountId
+    }
+    const option1 = verifySignerSignature(btoa(messageToSign), signatureMap, result.publicKey);
+    console.log(option1);
+
     const verified = result.publicKey.verify(
-      Buffer.from(messageToSign),
+      Buffer.from(prefixMessageToSign(btoa(messageToSign))),
       result.signature
     );
+
     alert(`The signature was ${verified ? "verified" : "not verified"}`);
   }
 


### PR DESCRIPTION
Under the hood, the `signAuth` method converts the message to a base64 string here: https://github.com/buidler-labs/hashgraph-react-wallets/blob/42a04d00b5485c4c9eaa1002932c26c17db6c9e4/src/actions/account.actions.ts#L157

Then the wallet adds a prefix to the signature as described here: https://docs.reown.com/advanced/multichain/rpc-reference/hedera-rpc#hedera-signmessage

There are some helper methods here: https://github.com/hashgraph/hedera-wallet-connect/blob/1dfc9b7d1dc56b272269dc9be799a462c8abc6fd/src/lib/shared/utils.ts#L230

To successfully verify the "Hello, World!" message, we have to verify the signature on the prefixed base64 encoding, which is actually something like this: "Hedera Signed Message:
20SGVsbG8sIHdvcmxkIQ=="